### PR TITLE
Updating version to 1.17.0-rc.2

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.dapr</groupId>
             <artifactId>testcontainers-dapr</artifactId>
-            <version>1.16.1</version>
+            <version>1.17.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/examples/src/main/java/io/quarkiverse/dapr/workflows/WorkflowsResource.java
+++ b/examples/src/main/java/io/quarkiverse/dapr/workflows/WorkflowsResource.java
@@ -11,8 +11,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import io.dapr.workflows.client.DaprWorkflowClient;
+import io.dapr.workflows.client.WorkflowInstanceStatus;
 import io.dapr.workflows.client.WorkflowRuntimeStatus;
-import io.dapr.workflows.client.WorkflowState;
 import io.quarkiverse.dapr.workflows.rest.UserWorkflow;
 import io.quarkiverse.dapr.workflows.simple.DemoChainWorkflow;
 import io.quarkus.logging.Log;
@@ -56,7 +56,7 @@ public class WorkflowsResource {
     @Path("/{workflowId}/result")
     public Response workflowId(@PathParam("workflowId") String workflowId) {
 
-        WorkflowState state = daprWorkflowClient.getWorkflowState(workflowId, true);
+        WorkflowInstanceStatus state = daprWorkflowClient.getInstanceState(workflowId, true);
         assert state != null;
 
         if (state.getRuntimeStatus().equals(WorkflowRuntimeStatus.COMPLETED)) {

--- a/examples/src/main/resources/application.properties
+++ b/examples/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-quarkus.dapr.devservices.daprd-image=daprio/daprd:1.15.4
+quarkus.dapr.devservices.daprd-image=daprio/daprd:1.17.0-rc.2
 quarkus.dapr.workflow.enabled=true
 
 quarkus.rest-client.users-api.url=http://localhost:${quarkus.wiremock.devservices.port}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.31.0</quarkus.version>
-    <dapr.version>1.16.1-rc-4</dapr.version>
+    <dapr.version>1.17.0-SNAPSHOT</dapr.version>
     <okhttp.version>5.3.2</okhttp.version>
     <assertj.version>3.27.7</assertj.version>
   </properties>


### PR DESCRIPTION
Updating to version 1.17.0-rc.2 images and 1.17.0-SNAPSHOT java deps. 

Tests still fail, but now the workflows are being executed. 🥳

@mcruzdev I need your help to troubleshoot this: 

```
2026-01-28 08:53:35,879 WARNING [io.dapr.durabletask] (pool-7-thread-1) The orchestrator failed with an unhandled exception: io.dapr.durabletask.TaskFailedException: Task 'io.quarkiverse.dapr.workflows.rest.GetUserWorkflowActivity' (#0) failed with an unhandled exception: Cannot invoke "io.quarkiverse.dapr.workflows.rest.UsersRestClient.getByID(String)" because "this.usersRestClient" is null
```

It looks like an injection issue within the Workflow Activity. 

Full output for running: `WorkflowsResourceTest`
```
/Users/salaboy/.sdkman/candidates/java/21.0.5-tem/bin/java -javaagent:/Users/salaboy/Library/Caches/JetBrains/IntelliJIdea2025.2/captureAgent/debugger-agent.jar=file:///var/folders/v1/5_x2rwfd2gg5hzfbqlkqlb640000gn/T/capture9106276545904195505.props -ea -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dmaven.home=/Applications/IntelliJ IDEA.app/Contents/plugins/maven/lib/maven3 -Dmaven.repo.local=/Users/salaboy/.m2/repository -Djava.io.tmpdir=/Users/salaboy/code/my-forks/matheus/quarkus-dapr/examples/target -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=63537 -Dkotlinx.coroutines.debug.enable.creation.stack.trace=false -Ddebugger.agent.enable.coroutines=true -Dkotlinx.coroutines.debug.enable.flows.stack.trace=true -Dkotlinx.coroutines.debug.enable.mutable.state.flows.stack.trace=true -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 -classpath /Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar:/Applications/IntelliJ IDEA.app/Contents/plugins/junit/lib/junit5-rt.jar:/Applications/IntelliJ IDEA.app/Contents/plugins/junit/lib/junit-rt.jar:/Users/salaboy/code/my-forks/matheus/quarkus-dapr/examples/target/test-classes:/Users/salaboy/code/my-forks/matheus/quarkus-dapr/examples/target/classes:/Users/salaboy/.m2/repository/io/quarkus/quarkus-arc/3.31.0/quarkus-arc-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/arc/arc/3.31.0/arc-3.31.0.jar:/Users/salaboy/.m2/repository/jakarta/enterprise/jakarta.enterprise.cdi-api/4.1.0/jakarta.enterprise.cdi-api-4.1.0.jar:/Users/salaboy/.m2/repository/jakarta/enterprise/jakarta.enterprise.lang-model/4.1.0/jakarta.enterprise.lang-model-4.1.0.jar:/Users/salaboy/.m2/repository/jakarta/el/jakarta.el-api/6.0.1/jakarta.el-api-6.0.1.jar:/Users/salaboy/.m2/repository/jakarta/interceptor/jakarta.interceptor-api/2.2.0/jakarta.interceptor-api-2.2.0.jar:/Users/salaboy/.m2/repository/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.jar:/Users/salaboy/.m2/repository/jakarta/transaction/jakarta.transaction-api/2.0.1/jakarta.transaction-api-2.0.1.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/mutiny/3.1.0/mutiny-3.1.0.jar:/Users/salaboy/.m2/repository/org/jctools/jctools-core/4.0.5/jctools-core-4.0.5.jar:/Users/salaboy/.m2/repository/org/jboss/logging/jboss-logging/3.6.1.Final/jboss-logging-3.6.1.Final.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-core/3.31.0/quarkus-core-3.31.0.jar:/Users/salaboy/.m2/repository/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-os/2.15.0/smallrye-common-os-2.15.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-ide-launcher/3.31.0/quarkus-ide-launcher-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-development-mode-spi/3.31.0/quarkus-development-mode-spi-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/config/smallrye-config/3.15.1/smallrye-config-3.15.1.jar:/Users/salaboy/.m2/repository/io/smallrye/config/smallrye-config-core/3.15.1/smallrye-config-core-3.15.1.jar:/Users/salaboy/.m2/repository/io/smallrye/config/smallrye-config-common/3.15.1/smallrye-config-common-3.15.1.jar:/Users/salaboy/.m2/repository/org/jboss/logmanager/jboss-logmanager/3.2.0.Final/jboss-logmanager-3.2.0.Final.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-constraint/2.15.0/smallrye-common-constraint-2.15.0.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-cpu/2.15.0/smallrye-common-cpu-2.15.0.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-expression/2.15.0/smallrye-common-expression-2.15.0.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-net/2.15.0/smallrye-common-net-2.15.0.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-ref/2.15.0/smallrye-common-ref-2.15.0.jar:/Users/salaboy/.m2/repository/jakarta/json/jakarta.json-api/2.1.3/jakarta.json-api-2.1.3.jar:/Users/salaboy/.m2/repository/org/jboss/threads/jboss-threads/3.9.2/jboss-threads-3.9.2.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-function/2.15.0/smallrye-common-function-2.15.0.jar:/Users/salaboy/.m2/repository/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar:/Users/salaboy/.m2/repository/org/jboss/slf4j/slf4j-jboss-logmanager/2.0.2.Final/slf4j-jboss-logmanager-2.0.2.Final.jar:/Users/salaboy/.m2/repository/org/wildfly/common/wildfly-common/2.0.1/wildfly-common-2.0.1.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-registry/3.31.0/quarkus-registry-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-runner/3.31.0/quarkus-bootstrap-runner-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-fs-util/1.3.0/quarkus-fs-util-1.3.0.jar:/Users/salaboy/.m2/repository/org/eclipse/microprofile/context-propagation/microprofile-context-propagation-api/1.3/microprofile-context-propagation-api-1.3.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest/3.31.0/quarkus-rest-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-common/3.31.0/quarkus-rest-common-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/resteasy/reactive/resteasy-reactive-common/3.31.0/resteasy-reactive-common-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/resteasy/reactive/resteasy-reactive-common-types/3.31.0/resteasy-reactive-common-types-3.31.0.jar:/Users/salaboy/.m2/repository/org/reactivestreams/reactive-streams/1.0.4/reactive-streams-1.0.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/mutiny-zero-flow-adapters/1.1.1/mutiny-zero-flow-adapters-1.1.1.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-vertx/3.31.0/quarkus-vertx-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-netty/3.31.0/quarkus-netty-3.31.0.jar:/Users/salaboy/.m2/repository/io/netty/netty-codec/4.1.130.Final/netty-codec-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-codec-haproxy/4.1.130.Final/netty-codec-haproxy-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-vertx-latebound-mdc-provider/3.31.0/quarkus-vertx-latebound-mdc-provider-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/smallrye-fault-tolerance-vertx/6.10.0/smallrye-fault-tolerance-vertx-6.10.0.jar:/Users/salaboy/.m2/repository/io/quarkus/resteasy/reactive/resteasy-reactive-vertx/3.31.0/resteasy-reactive-vertx-3.31.0.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-web/4.5.24/vertx-web-4.5.24.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-web-common/4.5.24/vertx-web-common-4.5.24.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-auth-common/4.5.24/vertx-auth-common-4.5.24.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-bridge-common/4.5.24/vertx-bridge-common-4.5.24.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-core/3.21.4/smallrye-mutiny-vertx-core-3.21.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-runtime/3.21.4/smallrye-mutiny-vertx-runtime-3.21.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/vertx-mutiny-generator/3.21.4/vertx-mutiny-generator-3.21.4.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-codegen/4.5.24/vertx-codegen-4.5.24.jar:/Users/salaboy/.m2/repository/io/quarkus/resteasy/reactive/resteasy-reactive/3.31.0/resteasy-reactive-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/vertx/utils/quarkus-vertx-utils/3.31.0/quarkus-vertx-utils-3.31.0.jar:/Users/salaboy/.m2/repository/jakarta/ws/rs/jakarta.ws.rs-api/3.1.0/jakarta.ws.rs-api-3.1.0.jar:/Users/salaboy/.m2/repository/org/jboss/logging/commons-logging-jboss-logging/1.0.0.Final/commons-logging-jboss-logging-1.0.0.Final.jar:/Users/salaboy/.m2/repository/jakarta/xml/bind/jakarta.xml.bind-api/4.0.4/jakarta.xml.bind-api-4.0.4.jar:/Users/salaboy/.m2/repository/jakarta/activation/jakarta.activation-api/2.1.4/jakarta.activation-api-2.1.4.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-vertx-http/3.31.0/quarkus-vertx-http-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-security-runtime-spi/3.31.0/quarkus-security-runtime-spi-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-tls-registry/3.31.0/quarkus-tls-registry-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-tls-registry-spi/3.31.0/quarkus-tls-registry-spi-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/certs/smallrye-private-key-pem-parser/0.9.2/smallrye-private-key-pem-parser-0.9.2.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-credentials/3.31.0/quarkus-credentials-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-vertx-context/2.15.0/smallrye-common-vertx-context-2.15.0.jar:/Users/salaboy/.m2/repository/io/quarkus/security/quarkus-security/2.3.2/quarkus-security-2.3.2.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-web/3.21.4/smallrye-mutiny-vertx-web-3.21.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-web-common/3.21.4/smallrye-mutiny-vertx-web-common-3.21.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-auth-common/3.21.4/smallrye-mutiny-vertx-auth-common-3.21.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-bridge-common/3.21.4/smallrye-mutiny-vertx-bridge-common-3.21.4.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/smallrye-mutiny-vertx-uri-template/3.21.4/smallrye-mutiny-vertx-uri-template-3.21.4.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-uri-template/4.5.24/vertx-uri-template-4.5.24.jar:/Users/salaboy/.m2/repository/org/crac/crac/1.5.0/crac-1.5.0.jar:/Users/salaboy/.m2/repository/com/aayushatharva/brotli4j/brotli4j/1.16.0/brotli4j-1.16.0.jar:/Users/salaboy/.m2/repository/com/aayushatharva/brotli4j/service/1.16.0/service-1.16.0.jar:/Users/salaboy/.m2/repository/com/aayushatharva/brotli4j/native-osx-aarch64/1.16.0/native-osx-aarch64-1.16.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-jsonp/3.31.0/quarkus-jsonp-3.31.0.jar:/Users/salaboy/.m2/repository/org/eclipse/parsson/parsson/1.1.7/parsson-1.1.7.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-virtual-threads/3.31.0/quarkus-virtual-threads-3.31.0.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-core/4.5.24/vertx-core-4.5.24.jar:/Users/salaboy/.m2/repository/io/netty/netty-common/4.1.130.Final/netty-common-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-buffer/4.1.130.Final/netty-buffer-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-transport/4.1.130.Final/netty-transport-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-handler/4.1.130.Final/netty-handler-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-handler-proxy/4.1.130.Final/netty-handler-proxy-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-codec-socks/4.1.130.Final/netty-codec-socks-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-codec-http/4.1.130.Final/netty-codec-http-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-codec-http2/4.1.130.Final/netty-codec-http2-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-resolver/4.1.130.Final/netty-resolver-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-resolver-dns/4.1.130.Final/netty-resolver-dns-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-codec-dns/4.1.130.Final/netty-codec-dns-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-junit/3.31.0/quarkus-junit-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-core/3.31.0/quarkus-bootstrap-core-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-classloader-commons/3.31.0/quarkus-classloader-commons-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-app-model/3.31.0/quarkus-bootstrap-app-model-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-json/3.31.0/quarkus-bootstrap-json-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-io/2.15.0/smallrye-common-io-2.15.0.jar:/Users/salaboy/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M4/org.eclipse.sisu.inject-0.9.0.M4.jar:/Users/salaboy/.m2/repository/org/ow2/asm/asm/9.9.1/asm-9.9.1.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-test-common/3.31.0/quarkus-test-common-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-core-deployment/3.31.0/quarkus-core-deployment-3.31.0.jar:/Users/salaboy/.m2/repository/org/aesh/readline/2.6/readline-2.6.jar:/Users/salaboy/.m2/repository/org/fusesource/jansi/jansi/2.4.0/jansi-2.4.0.jar:/Users/salaboy/.m2/repository/org/aesh/aesh/2.8.2/aesh-2.8.2.jar:/Users/salaboy/.m2/repository/org/apache/commons/commons-compress/1.28.0/commons-compress-1.28.0.jar:/Users/salaboy/.m2/repository/io/quarkus/gizmo/gizmo/1.10.1/gizmo-1.10.1.jar:/Users/salaboy/.m2/repository/org/ow2/asm/asm-util/9.9.1/asm-util-9.9.1.jar:/Users/salaboy/.m2/repository/org/ow2/asm/asm-analysis/9.9.1/asm-analysis-9.9.1.jar:/Users/salaboy/.m2/repository/io/quarkus/gizmo/gizmo2/2.0.0/gizmo2-2.0.0.jar:/Users/salaboy/.m2/repository/io/smallrye/classfile/jdk-classfile-backport/26.cr1/jdk-classfile-backport-26.cr1.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-resource/2.15.0/smallrye-common-resource-2.15.0.jar:/Users/salaboy/.m2/repository/io/smallrye/jandex-gizmo2/3.5.3/jandex-gizmo2-3.5.3.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-process/2.15.0/smallrye-common-process-2.15.0.jar:/Users/salaboy/.m2/repository/org/ow2/asm/asm-commons/9.9.1/asm-commons-9.9.1.jar:/Users/salaboy/.m2/repository/org/ow2/asm/asm-tree/9.9.1/asm-tree-9.9.1.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-hibernate-validator-spi/3.31.0/quarkus-hibernate-validator-spi-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-class-change-agent/3.31.0/quarkus-class-change-agent-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-builder/3.31.0/quarkus-builder-3.31.0.jar:/Users/salaboy/.m2/repository/org/graalvm/sdk/nativeimage/23.1.2/nativeimage-23.1.2.jar:/Users/salaboy/.m2/repository/org/graalvm/sdk/word/23.1.2/word-23.1.2.jar:/Users/salaboy/.m2/repository/org/junit/platform/junit-platform-launcher/6.0.2/junit-platform-launcher-6.0.2.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-maven-resolver/3.31.0/quarkus-bootstrap-maven-resolver-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/beanbag/smallrye-beanbag-maven/1.6.1/smallrye-beanbag-maven-1.6.1.jar:/Users/salaboy/.m2/repository/io/smallrye/beanbag/smallrye-beanbag-sisu/1.6.1/smallrye-beanbag-sisu-1.6.1.jar:/Users/salaboy/.m2/repository/io/smallrye/beanbag/smallrye-beanbag/1.6.1/smallrye-beanbag-1.6.1.jar:/Users/salaboy/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-artifact/3.9.12/maven-artifact-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-builder-support/3.9.12/maven-builder-support-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-model/3.9.12/maven-model-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-model-builder/3.9.12/maven-model-builder-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-repository-metadata/3.9.12/maven-repository-metadata-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-settings/3.9.12/maven-settings-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-api/1.9.25/maven-resolver-api-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-impl/1.9.25/maven-resolver-impl-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-named-locks/1.9.25/maven-resolver-named-locks-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-spi/1.9.25/maven-resolver-spi-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-util/1.9.25/maven-resolver-util-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-transport-http/1.9.25/maven-resolver-transport-http-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/wagon/wagon-provider-api/3.5.3/wagon-provider-api-3.5.3.jar:/Users/salaboy/.m2/repository/org/apache/maven/wagon/wagon-http-shared/3.5.3/wagon-http-shared-3.5.3.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-xml/4.0.2/plexus-xml-4.0.2.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-xml-impl/4.0.0-alpha-7/maven-xml-impl-4.0.0-alpha-7.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-api-xml/4.0.0-alpha-7/maven-api-xml-4.0.0-alpha-7.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-api-meta/4.0.0-alpha-7/maven-api-meta-4.0.0-alpha-7.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-maven4-resolver/3.31.0/quarkus-bootstrap-maven4-resolver-3.31.0.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-embedder/3.9.12/maven-embedder-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-core/3.9.12/maven-core-3.9.12.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-plugin-api/3.9.12/maven-plugin-api-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.4.2/maven-shared-utils-3.4.2.jar:/Users/salaboy/.m2/repository/com/google/inject/guice/5.1.0/guice-5.1.0-classes.jar:/Users/salaboy/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/Users/salaboy/.m2/repository/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar:/Users/salaboy/.m2/repository/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar:/Users/salaboy/.m2/repository/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar:/Users/salaboy/.m2/repository/commons-cli/commons-cli/1.11.0/commons-cli-1.11.0.jar:/Users/salaboy/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M4/org.eclipse.sisu.plexus-0.9.0.M4.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-settings-builder/3.9.12/maven-settings-builder-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/maven-resolver-provider/3.9.12/maven-resolver-provider-3.9.12.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-connector-basic/1.9.25/maven-resolver-connector-basic-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/resolver/maven-resolver-transport-wagon/1.9.25/maven-resolver-transport-wagon-1.9.25.jar:/Users/salaboy/.m2/repository/org/apache/maven/wagon/wagon-http/3.5.3/wagon-http-3.5.3.jar:/Users/salaboy/.m2/repository/org/apache/maven/wagon/wagon-file/3.5.3/wagon-file-3.5.3.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-bootstrap-gradle-resolver/3.31.0/quarkus-bootstrap-gradle-resolver-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/jandex/3.5.3/jandex-3.5.3.jar:/Users/salaboy/.m2/repository/commons-io/commons-io/2.21.0/commons-io-2.21.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-junit-config/3.31.0/quarkus-junit-config-3.31.0.jar:/Users/salaboy/.m2/repository/org/junit/jupiter/junit-jupiter-api/6.0.2/junit-jupiter-api-6.0.2.jar:/Users/salaboy/.m2/repository/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar:/Users/salaboy/.m2/repository/org/junit/platform/junit-platform-commons/6.0.2/junit-platform-commons-6.0.2.jar:/Users/salaboy/.m2/repository/org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar:/Users/salaboy/.m2/repository/org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar:/Users/salaboy/.m2/repository/org/junit/jupiter/junit-jupiter/6.0.2/junit-jupiter-6.0.2.jar:/Users/salaboy/.m2/repository/org/junit/jupiter/junit-jupiter-params/6.0.2/junit-jupiter-params-6.0.2.jar:/Users/salaboy/.m2/repository/org/junit/jupiter/junit-jupiter-engine/6.0.2/junit-jupiter-engine-6.0.2.jar:/Users/salaboy/.m2/repository/org/junit/platform/junit-platform-engine/6.0.2/junit-platform-engine-6.0.2.jar:/Users/salaboy/.m2/repository/io/rest-assured/rest-assured/5.5.6/rest-assured-5.5.6.jar:/Users/salaboy/.m2/repository/org/apache/groovy/groovy/4.0.22/groovy-4.0.22.jar:/Users/salaboy/.m2/repository/org/apache/groovy/groovy-xml/4.0.22/groovy-xml-4.0.22.jar:/Users/salaboy/.m2/repository/org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar:/Users/salaboy/.m2/repository/org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar:/Users/salaboy/.m2/repository/commons-codec/commons-codec/1.20.0/commons-codec-1.20.0.jar:/Users/salaboy/.m2/repository/org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar:/Users/salaboy/.m2/repository/org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar:/Users/salaboy/.m2/repository/org/ccil/cowan/tagsoup/tagsoup/1.2.1/tagsoup-1.2.1.jar:/Users/salaboy/.m2/repository/io/rest-assured/json-path/5.5.6/json-path-5.5.6.jar:/Users/salaboy/.m2/repository/org/apache/groovy/groovy-json/4.0.22/groovy-json-4.0.22.jar:/Users/salaboy/.m2/repository/io/rest-assured/rest-assured-common/5.5.6/rest-assured-common-5.5.6.jar:/Users/salaboy/.m2/repository/io/rest-assured/xml-path/5.5.6/xml-path-5.5.6.jar:/Users/salaboy/.m2/repository/org/apache/commons/commons-lang3/3.20.0/commons-lang3-3.20.0.jar:/Users/salaboy/code/my-forks/matheus/quarkus-dapr/runtime/target/classes:/Users/salaboy/.m2/repository/io/quarkus/quarkus-grpc/3.31.0/quarkus-grpc-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-grpc-api/3.31.0/quarkus-grpc-api-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-grpc-common/3.31.0/quarkus-grpc-common-3.31.0.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-grpc/4.5.24/vertx-grpc-4.5.24.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-grpc-server/4.5.24/vertx-grpc-server-4.5.24.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-grpc-common/4.5.24/vertx-grpc-common-4.5.24.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-grpc-client/4.5.24/vertx-grpc-client-4.5.24.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-core/1.78.0/grpc-core-1.78.0.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-context/1.78.0/grpc-context-1.78.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-grpc-reflection/3.31.0/quarkus-grpc-reflection-3.31.0.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-protobuf/1.78.0/grpc-protobuf-1.78.0.jar:/Users/salaboy/.m2/repository/com/google/api/grpc/proto-google-common-protos/2.63.1/proto-google-common-protos-2.63.1.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-protobuf-lite/1.78.0/grpc-protobuf-lite-1.78.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-smallrye-stork/3.31.0/quarkus-smallrye-stork-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/stork/stork-api/2.7.3/stork-api-2.7.3.jar:/Users/salaboy/.m2/repository/io/smallrye/stork/stork-core/2.7.3/stork-core-2.7.3.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-grpc-stubs/3.31.0/quarkus-grpc-stubs-3.31.0.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-stub/1.78.0/grpc-stub-1.78.0.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-api/1.78.0/grpc-api-1.78.0.jar:/Users/salaboy/.m2/repository/com/google/guava/guava/33.5.0-jre/guava-33.5.0-jre.jar:/Users/salaboy/.m2/repository/com/google/errorprone/error_prone_annotations/2.46.0/error_prone_annotations-2.46.0.jar:/Users/salaboy/.m2/repository/com/google/protobuf/protobuf-java-util/4.32.1/protobuf-java-util-4.32.1.jar:/Users/salaboy/.m2/repository/com/google/protobuf/protobuf-java/4.32.1/protobuf-java-4.32.1.jar:/Users/salaboy/.m2/repository/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/Users/salaboy/.m2/repository/com/google/code/gson/gson/2.13.2/gson-2.13.2.jar:/Users/salaboy/.m2/repository/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-annotation/2.15.0/smallrye-common-annotation-2.15.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-jackson/3.31.0/quarkus-rest-jackson-3.31.0.jar:/Users/salaboy/.m2/repository/io/dapr/dapr-sdk/1.16.1-rc-4/dapr-sdk-1.16.1-rc-4.jar:/Users/salaboy/.m2/repository/io/dapr/dapr-sdk-autogen/1.16.1-rc-4/dapr-sdk-autogen-1.16.1-rc-4.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.20.1/jackson-databind-2.20.1.jar:/Users/salaboy/.m2/repository/io/projectreactor/reactor-core/3.5.0/reactor-core-3.5.0.jar:/Users/salaboy/.m2/repository/org/assertj/assertj-core/3.27.3/assertj-core-3.27.3.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-netty/1.78.0/grpc-netty-1.78.0.jar:/Users/salaboy/.m2/repository/org/codehaus/mojo/animal-sniffer-annotations/1.26/animal-sniffer-annotations-1.26.jar:/Users/salaboy/.m2/repository/io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar:/Users/salaboy/.m2/repository/io/netty/netty-transport-native-unix-common/4.1.130.Final/netty-transport-native-unix-common-4.1.130.Final.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-util/1.78.0/grpc-util-1.78.0.jar:/Users/salaboy/.m2/repository/io/dapr/dapr-sdk-actors/1.16.1-rc-4/dapr-sdk-actors-1.16.1-rc-4.jar:/Users/salaboy/.m2/repository/io/dapr/dapr-sdk-workflows/1.16.1-rc-4/dapr-sdk-workflows-1.16.1-rc-4.jar:/Users/salaboy/.m2/repository/io/dapr/durabletask-client/1.5.10/durabletask-client-1.5.10.jar:/Users/salaboy/.m2/repository/io/grpc/grpc-netty-shaded/1.78.0/grpc-netty-shaded-1.78.0.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.74.Final/netty-tcnative-boringssl-static-2.0.74.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-classes/2.0.74.Final/netty-tcnative-classes-2.0.74.Final.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.74.Final/netty-tcnative-boringssl-static-2.0.74.Final-linux-x86_64.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.74.Final/netty-tcnative-boringssl-static-2.0.74.Final-linux-aarch_64.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.74.Final/netty-tcnative-boringssl-static-2.0.74.Final-osx-x86_64.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.74.Final/netty-tcnative-boringssl-static-2.0.74.Final-osx-aarch_64.jar:/Users/salaboy/.m2/repository/io/netty/netty-tcnative-boringssl-static/2.0.74.Final/netty-tcnative-boringssl-static-2.0.74.Final-windows-x86_64.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.20.1/jackson-core-2.20.1.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.20/jackson-annotations-2.20.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.20.1/jackson-datatype-jsr310-2.20.1.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-junit-mockito/3.31.0/quarkus-junit-mockito-3.31.0.jar:/Users/salaboy/.m2/repository/org/mockito/mockito-junit-jupiter/5.21.0/mockito-junit-jupiter-5.21.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-junit-mockito-config/3.31.0/quarkus-junit-mockito-config-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-arc-deployment/3.31.0/quarkus-arc-deployment-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-smallrye-context-propagation-spi/3.31.0/quarkus-smallrye-context-propagation-spi-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-devui-deployment-spi/3.31.0/quarkus-devui-deployment-spi-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-arc-dev/3.31.0/quarkus-arc-dev-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/arc/arc-processor/3.31.0/arc-processor-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-arc-test-supplement/3.31.0/quarkus-arc-test-supplement-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-arc-test-supplement-decorator/3.31.0/quarkus-arc-test-supplement-decorator-3.31.0.jar:/Users/salaboy/.m2/repository/org/mockito/mockito-core/5.21.0/mockito-core-5.21.0.jar:/Users/salaboy/.m2/repository/net/bytebuddy/byte-buddy/1.17.8/byte-buddy-1.17.8.jar:/Users/salaboy/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar:/Users/salaboy/.m2/repository/org/objenesis/objenesis/3.3/objenesis-3.3.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-mutiny/3.31.0/quarkus-mutiny-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-smallrye-context-propagation/3.31.0/quarkus-smallrye-context-propagation-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/smallrye-context-propagation/2.3.0/smallrye-context-propagation-2.3.0.jar:/Users/salaboy/.m2/repository/io/smallrye/smallrye-context-propagation-api/2.3.0/smallrye-context-propagation-api-2.3.0.jar:/Users/salaboy/.m2/repository/io/smallrye/smallrye-context-propagation-storage/2.3.0/smallrye-context-propagation-storage-2.3.0.jar:/Users/salaboy/.m2/repository/io/smallrye/reactive/mutiny-smallrye-context-propagation/3.1.0/mutiny-smallrye-context-propagation-3.1.0.jar:/Users/salaboy/.m2/repository/org/awaitility/awaitility/4.3.0/awaitility-4.3.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-smallrye-openapi/3.31.0/quarkus-smallrye-openapi-3.31.0.jar:/Users/salaboy/.m2/repository/io/smallrye/smallrye-open-api-core/4.2.3/smallrye-open-api-core-4.2.3.jar:/Users/salaboy/.m2/repository/org/eclipse/microprofile/openapi/microprofile-openapi-api/4.1.1/microprofile-openapi-api-4.1.1.jar:/Users/salaboy/.m2/repository/org/eclipse/microprofile/config/microprofile-config-api/3.1/microprofile-config-api-3.1.jar:/Users/salaboy/.m2/repository/io/smallrye/smallrye-open-api-model/4.2.3/smallrye-open-api-model-4.2.3.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.20.1/jackson-dataformat-yaml-2.20.1.jar:/Users/salaboy/.m2/repository/org/yaml/snakeyaml/2.5/snakeyaml-2.5.jar:/Users/salaboy/.m2/repository/io/smallrye/common/smallrye-common-classloader/2.15.0/smallrye-common-classloader-2.15.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-swagger-ui/3.31.0/quarkus-swagger-ui-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-client-jackson/3.31.0/quarkus-rest-client-jackson-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/resteasy/reactive/resteasy-reactive-jackson/3.31.0/resteasy-reactive-jackson-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-jackson-common/3.31.0/quarkus-rest-jackson-common-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-jackson/3.31.0/quarkus-jackson-3.31.0.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.20.1/jackson-datatype-jdk8-2.20.1.jar:/Users/salaboy/.m2/repository/com/fasterxml/jackson/module/jackson-module-parameter-names/2.20.1/jackson-module-parameter-names-2.20.1.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-client/3.31.0/quarkus-rest-client-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-client-jaxrs/3.31.0/quarkus-rest-client-jaxrs-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/resteasy/reactive/resteasy-reactive-client/3.31.0/resteasy-reactive-client-3.31.0.jar:/Users/salaboy/.m2/repository/io/vertx/vertx-web-client/4.5.24/vertx-web-client-4.5.24.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-rest-client-config/3.31.0/quarkus-rest-client-config-3.31.0.jar:/Users/salaboy/.m2/repository/io/quarkus/quarkus-proxy-registry/3.31.0/quarkus-proxy-registry-3.31.0.jar:/Users/salaboy/.m2/repository/org/eclipse/microprofile/rest/client/microprofile-rest-client-api/4.0/microprofile-rest-client-api-4.0.jar:/Users/salaboy/.m2/repository/io/quarkiverse/wiremock/quarkus-wiremock/1.5.1/quarkus-wiremock-1.5.1.jar com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit5 io.quarkiverse.dapr.workflows.WorkflowsResourceTest
2026-01-28 08:53:30,499 INFO  [org.testcontainers.DockerClientFactory] (build-12) Testcontainers version: 2.0.3
2026-01-28 08:53:30,672 INFO  [org.testcontainers.dockerclient.DockerClientProviderStrategy] (build-12) Loaded org.testcontainers.dockerclient.UnixSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
2026-01-28 08:53:30,681 WARN  [org.testcontainers.dockerclient.DockerClientProviderStrategy] (build-12) DOCKER_HOST tcp://127.0.0.1:53210 is not listening: java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.connect0(Native Method)
	at java.base/sun.nio.ch.Net.connect(Net.java:589)
	at java.base/sun.nio.ch.Net.connect(Net.java:578)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:583)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:751)
	at java.base/java.net.Socket.connect(Socket.java:686)
	at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$test$3(DockerClientProviderStrategy.java:214)
	at org.testcontainers.shaded.org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
	at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
	at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:317)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

2026-01-28 08:53:30,683 WARN  [org.testcontainers.dockerclient.DockerClientProviderStrategy] (build-12) DOCKER_HOST tcp://127.0.0.1:53210 is not listening: java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.connect0(Native Method)
	at java.base/sun.nio.ch.Net.connect(Net.java:589)
	at java.base/sun.nio.ch.Net.connect(Net.java:578)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:583)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:751)
	at java.base/java.net.Socket.connect(Socket.java:686)
	at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$test$3(DockerClientProviderStrategy.java:214)
	at org.testcontainers.shaded.org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
	at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
	at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:317)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

2026-01-28 08:53:30,885 INFO  [io.quarkiverse.wiremock.devservice.WireMockServer] (build-18) Using HTTP server impl: Jetty11HttpServer
2026-01-28 08:53:30,891 INFO  [org.testcontainers.dockerclient.DockerClientProviderStrategy] (build-12) Found Docker environment with local Unix socket (unix:///var/run/docker.sock)
2026-01-28 08:53:30,892 INFO  [org.testcontainers.DockerClientFactory] (build-12) Docker host IP address is localhost
2026-01-28 08:53:30,905 INFO  [org.testcontainers.DockerClientFactory] (build-12) Connected to docker: 
  Server Version: 29.1.3
  API Version: 1.52
  Operating System: Docker Desktop
  Total Memory: 7836 MB
  Labels: 
    com.docker.desktop.address=unix:///Users/salaboy/Library/Containers/com.docker.docker/Data/docker-cli.sock
2026-01-28 08:53:30,911 INFO  [org.testcontainers.images.PullPolicy] (build-12) Image pull policy will be performed by: DefaultPullPolicy()
2026-01-28 08:53:30,913 INFO  [org.testcontainers.utility.ImageNameSubstitutor] (build-12) Image name substitution will be performed by: DefaultImageNameSubstitutor (composite of 'ConfigurationFileImageNameSubstitutor' and 'PrefixingImageNameSubstitutor')
2026-01-28 08:53:30,915 INFO  [org.testcontainers.DockerClientFactory] (build-12) Checking the system...
2026-01-28 08:53:30,915 INFO  [org.testcontainers.DockerClientFactory] (build-12) ✔︎ Docker server version should be at least 1.6.0
2026-01-28 08:53:32,065 INFO  [tc.testcontainers/sshd:1.3.0] (build-12) Creating container for image: testcontainers/sshd:1.3.0
2026-01-28 08:53:32,165 INFO  [tc.testcontainers/ryuk:0.13.0] (build-12) Creating container for image: testcontainers/ryuk:0.13.0
2026-01-28 08:53:32,248 INFO  [tc.testcontainers/ryuk:0.13.0] (build-12) Container testcontainers/ryuk:0.13.0 is starting: 9c5eb3f16742788acf23c5b5eb6ac2febaeec0628d03710a3026dc31aa4e1869
2026-01-28 08:53:32,512 INFO  [tc.testcontainers/ryuk:0.13.0] (build-12) Container testcontainers/ryuk:0.13.0 started in PT0.346532S
2026-01-28 08:53:32,563 INFO  [tc.testcontainers/sshd:1.3.0] (build-12) Container testcontainers/sshd:1.3.0 is starting: 612f53c56fda8fb47a2fddf41ed810b9c65deeed7b4243950ec8b083ead1b0c9
2026-01-28 08:53:32,773 INFO  [tc.testcontainers/sshd:1.3.0] (build-12) Container testcontainers/sshd:1.3.0 started in PT0.708156S
2026-01-28 08:53:32,854 INFO  [tc.daprio/placement:1.17.0-rc.2] (build-12) Creating container for image: daprio/placement:1.17.0-rc.2
2026-01-28 08:53:32,935 INFO  [tc.daprio/placement:1.17.0-rc.2] (build-12) Container daprio/placement:1.17.0-rc.2 is starting: 72870c41e678f2730c4d04327d573e006e94a2d06d0f77827a3841d5dca0fec4
2026-01-28 08:53:33,257 WARN  [org.testcontainers.containers.wait.internal.InternalCommandPortListeningCheck] (testcontainers-wait-0) An exception while executing the internal check: Container.ExecResult(exitCode=127, stdout=OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory
, stderr=)
2026-01-28 08:53:33,257 INFO  [tc.daprio/placement:1.17.0-rc.2] (build-12) Container daprio/placement:1.17.0-rc.2 started in PT0.402907S
2026-01-28 08:53:33,259 INFO  [tc.daprio/scheduler:1.17.0-rc.2] (build-12) Creating container for image: daprio/scheduler:1.17.0-rc.2
2026-01-28 08:53:33,368 INFO  [tc.daprio/scheduler:1.17.0-rc.2] (build-12) Container daprio/scheduler:1.17.0-rc.2 is starting: eab2c55f827e4e18db52932efd27f82e9a9b7c4fd8f3b3f13ba644a2fceb6e1d
2026-01-28 08:53:33,635 WARN  [org.testcontainers.containers.wait.internal.InternalCommandPortListeningCheck] (testcontainers-wait-0) An exception while executing the internal check: Container.ExecResult(exitCode=127, stdout=OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory
, stderr=)
2026-01-28 08:53:33,636 INFO  [tc.daprio/scheduler:1.17.0-rc.2] (build-12) Container daprio/scheduler:1.17.0-rc.2 started in PT0.377035S
2026-01-28 08:53:33,636 INFO  [io.dapr.testcontainers.DaprContainer] (build-12) > `daprd` Command: 

2026-01-28 08:53:33,636 INFO  [io.dapr.testcontainers.DaprContainer] (build-12) 	[./daprd, --app-id, local-dapr-app, --dapr-listen-addresses=0.0.0.0, --placement-host-address, placement:50005, --scheduler-host-address, scheduler:51005, --app-channel-address, host.testcontainers.internal, --app-port, 8081, --app-protocol, http, --log-level, DEBUG, --resources-path, /dapr-resources]

2026-01-28 08:53:33,645 INFO  [io.dapr.testcontainers.DaprContainer] (build-12) > Component YAML: 

2026-01-28 08:53:33,645 INFO  [io.dapr.testcontainers.DaprContainer] (build-12) 	
apiVersion: dapr.io/v1alpha1
kind: Component
metadata:
  name: kvstore
spec:
  type: state.in-memory
  version: v1
  metadata:
  - name: actorStateStore
    value: 'true'


2026-01-28 08:53:33,645 INFO  [io.dapr.testcontainers.DaprContainer] (build-12) > Subscription YAML: 

2026-01-28 08:53:33,645 INFO  [io.dapr.testcontainers.DaprContainer] (build-12) 	
apiVersion: dapr.io/v1alpha1
kind: Subscription
metadata:
  name: local
spec:
  pubsubname: pubsub
  topic: topic
  route: /events


2026-01-28 08:53:33,645 INFO  [tc.daprio/daprd:1.17.0-rc.2] (build-12) Creating container for image: daprio/daprd:1.17.0-rc.2
2026-01-28 08:53:33,790 INFO  [tc.daprio/daprd:1.17.0-rc.2] (build-12) Container daprio/daprd:1.17.0-rc.2 is starting: ddf292f9ebad91e6f7f361c1687efbcc73b1ef20257c3e16624f55b0a870001e
2026-01-28 08:53:34,121 INFO  [org.testcontainers.containers.wait.strategy.HttpWaitStrategy] (build-12) /hardcore_dewdney: Waiting for 60 seconds for URL: http://localhost:63556/v1.0/healthz/outbound (where port 63556 maps to container port 3500)
2026-01-28 08:53:34,133 INFO  [tc.daprio/daprd:1.17.0-rc.2] (build-12) Container daprio/daprd:1.17.0-rc.2 started in PT0.48806S
2026-01-28 08:53:34,141 INFO  [io.quarkiverse.dapr.deployment.DevServicesDaprProcessor] (build-12) Dev Services for Dapr started
2026-01-28 08:53:34,211 WARN  [io.quarkus.deployment.jvm] (main) Could not get access to jdk.internal.module API: this is required for Quarkus to adjust Java Modules configuration to match the various requirements of each extension. Please ensure this JVM is launched with --add-opens=java.base/java.lang.invoke=ALL-UNNAMED.
WARNING: A Java agent has been loaded dynamically (/Users/salaboy/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
2026-01-28 08:53:34,756 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) Registered Workflow: DemoChainWorkflow
2026-01-28 08:53:34,756 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) Registered Workflow: UserWorkflow
2026-01-28 08:53:34,756 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) Registered Activity: GetUserWorkflowActivity
2026-01-28 08:53:34,756 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) Registered Activity: UppercaseWorkflowActivity
2026-01-28 08:53:34,827 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) List of registered workflows: [io.quarkiverse.dapr.workflows.rest.UserWorkflow, io.quarkiverse.dapr.workflows.simple.DemoChainWorkflow]
2026-01-28 08:53:34,827 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) List of registered activities: [io.quarkiverse.dapr.workflows.simple.UppercaseWorkflowActivity, io.quarkiverse.dapr.workflows.rest.GetUserWorkflowActivity]
2026-01-28 08:53:34,827 INFO  [io.dapr.workflows.runtime.WorkflowRuntimeBuilder] (main) Successfully built dapr workflow runtime
2026-01-28 08:53:34,828 INFO  [io.dapr.durabletask] (Thread-41) Durable Task worker is connecting to sidecar at 127.0.0.1:63557.
2026-01-28 08:53:35,162 INFO  [io.quarkus] (main) examples 999-SNAPSHOT on JVM (powered by Quarkus 3.31.0) started in 5.452s. Listening on: http://localhost:8081
2026-01-28 08:53:35,162 INFO  [io.quarkus] (main) Profile test activated. 
2026-01-28 08:53:35,162 INFO  [io.quarkus] (main) Installed features: [cdi, compose, dapr, grpc-client, rest, rest-client, rest-client-jackson, rest-jackson, smallrye-context-propagation, smallrye-openapi, swagger-ui, vertx, wiremock]
2026-01-28 08:53:35,634 INFO  [io.quarkiverse.dapr.workflows.WorkflowsResource] (executor-thread-1) DemoChainWorkflow.class: io.quarkiverse.dapr.workflows.simple.DemoChainWorkflow
2026-01-28 08:53:35,735 INFO  [io.quarkiverse.dapr.workflows.simple.DemoChainWorkflow] (pool-7-thread-1) Workflow instance: fa6db960-dfef-4790-b609-47edcfec4381
2026-01-28 08:53:35,751 INFO  [io.quarkiverse.dapr.workflows.WorkflowsResource] (executor-thread-1) Starting DemoChainWorkflow with instance ID as fa6db960-dfef-4790-b609-47edcfec4381
2026-01-28 08:53:35,753 INFO  [io.quarkiverse.dapr.workflows.simple.UppercaseWorkflowActivity] (pool-7-thread-1) Before, let's call GreetingService: 
2026-01-28 08:53:35,764 WARNING [io.dapr.durabletask] (pool-7-thread-1) The orchestrator failed with an unhandled exception: io.dapr.durabletask.TaskFailedException: Task 'io.quarkiverse.dapr.workflows.simple.UppercaseWorkflowActivity' (#0) failed with an unhandled exception: Cannot invoke "io.quarkiverse.dapr.workflows.simple.GreetingService.sayHello()" because "this.greetingService" is null
2026-01-28 08:53:35,810 INFO  [io.quarkiverse.dapr.workflows.WorkflowsResource] (executor-thread-1) Current status FAILED
Request method:	GET
Request URI:	http://localhost:8081/workflows/fa6db960-dfef-4790-b609-47edcfec4381/result
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	workflowInstanceId=fa6db960-dfef-4790-b609-47edcfec4381
Headers:		Accept=*/*
Cookies:		<none>
Multiparts:		<none>
Body:			<none>

HTTP/1.1 200 OK
content-length: 0

java.lang.IllegalStateException: Expected response body to be verified as JSON, HTML or XML but no content-type was defined in the response.
Try registering a default parser using:
   RestAssured.defaultParser(<parser type>);
Content was:



	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:73)
	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:60)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:86)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:263)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
	at io.restassured.assertion.StreamVerifier.newAssertion(StreamVerifier.groovy:43)
	at io.restassured.internal.assertion.BodyMatcher.validate(BodyMatcher.java:93)
	at io.restassured.internal.assertion.BodyMatcherGroup.lambda$validate$0(BodyMatcherGroup.java:30)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.restassured.internal.assertion.BodyMatcherGroup.validate(BodyMatcherGroup.java:30)
	at io.restassured.internal.assertion.BodyMatcherGroup$validate$3.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:157)
	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure.validate(ResponseSpecificationImpl.groovy:499)
	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure$validate$1.call(Unknown Source)
	at io.restassured.internal.ResponseSpecificationImpl.validateResponseIfRequired(ResponseSpecificationImpl.groovy:696)
	at io.restassured.internal.ResponseSpecificationImpl.this$2$validateResponseIfRequired(ResponseSpecificationImpl.groovy)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:198)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:62)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:171)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:185)
	at io.restassured.internal.ResponseSpecificationImpl.body(ResponseSpecificationImpl.groovy:270)
	at io.restassured.specification.ResponseSpecification$body$2.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:171)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:212)
	at io.restassured.internal.ResponseSpecificationImpl.body(ResponseSpecificationImpl.groovy:117)
	at io.restassured.internal.ValidatableResponseOptionsImpl.body(ValidatableResponseOptionsImpl.java:244)
	at io.quarkiverse.dapr.workflows.WorkflowsResourceTest.shouldExecuteDemoChainWorkflow(WorkflowsResourceTest.java:46)

2026-01-28 08:53:35,871 INFO  [io.quarkiverse.dapr.workflows.rest.UserWorkflow] (pool-7-thread-1) Workflow instance: fd01b897-39a4-4048-b9c8-e152b5e9af89
2026-01-28 08:53:35,875 INFO  [io.quarkiverse.dapr.workflows.WorkflowsResource] (executor-thread-1) Starting UserWorkflow with instance ID as fd01b897-39a4-4048-b9c8-e152b5e9af89
2026-01-28 08:53:35,879 WARNING [io.dapr.durabletask] (pool-7-thread-1) The orchestrator failed with an unhandled exception: io.dapr.durabletask.TaskFailedException: Task 'io.quarkiverse.dapr.workflows.rest.GetUserWorkflowActivity' (#0) failed with an unhandled exception: Cannot invoke "io.quarkiverse.dapr.workflows.rest.UsersRestClient.getByID(String)" because "this.usersRestClient" is null
2026-01-28 08:53:35,884 INFO  [io.quarkiverse.dapr.workflows.WorkflowsResource] (executor-thread-1) Current status FAILED
Request method:	GET
Request URI:	http://localhost:8081/workflows/fd01b897-39a4-4048-b9c8-e152b5e9af89/result
Proxy:			<none>
Request params:	<none>
Query params:	<none>
Form params:	<none>
Path params:	workflowInstanceId=fd01b897-39a4-4048-b9c8-e152b5e9af89
Headers:		Accept=*/*
Cookies:		<none>
Multiparts:		<none>
Body:			<none>

HTTP/1.1 200 OK
content-length: 0

java.lang.IllegalStateException: Expected response body to be verified as JSON, HTML or XML but no content-type was defined in the response.
Try registering a default parser using:
   RestAssured.defaultParser(<parser type>);
Content was:



	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:73)
	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:60)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrap.callConstructor(ConstructorSite.java:86)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
	at io.restassured.assertion.StreamVerifier.newAssertion(StreamVerifier.groovy:43)
	at io.restassured.internal.assertion.BodyMatcher.validate(BodyMatcher.java:93)
	at io.restassured.internal.assertion.BodyMatcherGroup.lambda$validate$0(BodyMatcherGroup.java:30)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.restassured.internal.assertion.BodyMatcherGroup.validate(BodyMatcherGroup.java:30)
	at io.restassured.internal.assertion.BodyMatcherGroup$validate$3.call(Unknown Source)
	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure.validate(ResponseSpecificationImpl.groovy:499)
	at io.restassured.internal.ResponseSpecificationImpl$HamcrestAssertionClosure$validate$1.call(Unknown Source)
	at io.restassured.internal.ResponseSpecificationImpl.validateResponseIfRequired(ResponseSpecificationImpl.groovy:696)
	at io.restassured.internal.ResponseSpecificationImpl.this$2$validateResponseIfRequired(ResponseSpecificationImpl.groovy)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite.doInvoke(PlainObjectMetaMethodSite.java:43)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:198)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:62)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:185)
	at io.restassured.internal.ResponseSpecificationImpl.body(ResponseSpecificationImpl.groovy:270)
	at io.restassured.specification.ResponseSpecification$body$2.callCurrent(Unknown Source)
	at io.restassured.internal.ResponseSpecificationImpl.body(ResponseSpecificationImpl.groovy:117)
	at io.restassured.internal.ValidatableResponseOptionsImpl.body(ValidatableResponseOptionsImpl.java:244)
	at io.quarkiverse.dapr.workflows.WorkflowsResourceTest.shouldExecuteUserWorkflow(WorkflowsResourceTest.java:27)

2026-01-28 08:53:35,898 INFO  [io.quarkiverse.dapr.workflows.WorkflowRuntimeBuilderRecorder] (main) Shutdown context task: Closing WorkflowRuntime
2026-01-28 08:54:35,907 INFO  [io.dapr.durabletask] (Thread-41) The sidecar at address 127.0.0.1:63557 is unavailable. Will continue retrying.
2026-01-28 08:54:35,914 INFO  [io.quarkus] (main) examples stopped in 60.026s

Process finished with exit code 255

```

